### PR TITLE
Fix Debug build due to warning in simulink.c

### DIFF
--- a/sources/Mex/CMakeLists.txt
+++ b/sources/Mex/CMakeLists.txt
@@ -38,6 +38,9 @@ target_compile_warnings(Mex
     WARNINGS_AS_ERRORS ${TREAT_WARNINGS_AS_ERRORS}
     DEPENDS ENABLE_WARNINGS)
 
+# Fix https://github.com/robotology/blockfactory/issues/13
+target_compile_options(Mex PRIVATE -Wno-format-overflow)
+
 target_include_directories(Mex PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     ${Matlab_ROOT_DIR}/simulink/include)

--- a/sources/Mex/src/BlockFactory.cpp
+++ b/sources/Mex/src/BlockFactory.cpp
@@ -591,6 +591,8 @@ parameterTypeToString(const blockfactory::core::ParameterType& type)
         case blockfactory::core::ParameterType::STRUCT_CELL_STRING:
             return {"ParameterType::STRUCT_CELL_STRING", "std::string"};
     }
+
+    return {};
 }
 
 template <typename T>


### PR DESCRIPTION
The compiler option that is generating the warning in simulink.c was disabled for the `Mex` target. Note that in Debug by default warnings are treated as errors.

Fix #13 