### PR TITLE
Fix the compilation of the example

### DIFF
--- a/.ci/script.sh
+++ b/.ci/script.sh
@@ -12,6 +12,7 @@ if [ "$TRAVIS_CMAKE_GENERATOR" = "Visual Studio 15 2017" ] ; then
     cmake --build . --target INSTALL
     # Build the example
     cd $TRAVIS_BUILD_DIR/example
+    mkdir build && cd build
     cmake -G"$TRAVIS_CMAKE_GENERATOR" -A"${TRAVIS_CMAKE_ARCHITECTURE}" ..
     cmake --build . --config $TRAVIS_BUILD_TYPE
 else
@@ -21,6 +22,7 @@ else
     cmake --build . --target install
     # Build the example
     cd $TRAVIS_BUILD_DIR/example
+    mkdir build && cd build
     cmake -G"$TRAVIS_CMAKE_GENERATOR" -DCMAKE_BUILD_TYPE=$TRAVIS_BUILD_TYPE ..
     cmake --build .
 fi

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -32,7 +32,9 @@ endif()
 # Find the needed BlockFactory components:
 # - BlockFactoryCore contains the core classes such as Block and Signal
 # - BlockFactoryMex is required at runtime for loading the library from Simulink
-find_package(BlockFactory 1 REQUIRED COMPONENTS BlockFactoryCore BlockFactoryMex)
+find_package(BlockFactory
+    REQUIRED COMPONENTS BlockFactoryCore
+    OPTIONAL_COMPONENTS BlockFactoryMex)
 
 # Create the plugin library. This must be a SHARED library.
 add_library(ExampleToolbox SHARED


### PR DESCRIPTION
- Now the `Mex` component is optional in the example
- The CI script has been fixed, before the example was not compiled

Closes #17 