### PR TITLE
Polished and improved SimulinkBlockInformation

### DIFF
--- a/sources/Simulink/CMakeLists.txt
+++ b/sources/Simulink/CMakeLists.txt
@@ -2,34 +2,16 @@
 # This software may be modified and distributed under the terms of the
 # GNU Lesser General Public License v2.1 or any later version.
 
-add_library(SimulinkBlockInformationPrivate STATIC
-    src/SimulinkBlockInformationImpl.cpp
-    include/BlockFactory/Simulink/Private/SimulinkBlockInformationImpl.h)
-
-target_link_libraries(SimulinkBlockInformationPrivate
-    PUBLIC
-    BlockFactory::Core
-    mxpp)
-
-# Needed to access Simulink C APIs
-target_compile_definitions(SimulinkBlockInformationPrivate PRIVATE "MATLAB_MEX_FILE")
-target_compile_warnings(SimulinkBlockInformationPrivate
-    WARNINGS_AS_ERRORS ${TREAT_WARNINGS_AS_ERRORS}
-    DEPENDS ENABLE_WARNINGS)
-
-target_include_directories(SimulinkBlockInformationPrivate PRIVATE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    ${Matlab_INCLUDE_DIRS}
-    ${Matlab_ROOT_DIR}/simulink/include)
-
 # Compile S-Function
 matlab_add_mex(
     NAME Simulink
     OUTPUT_NAME BlockFactory
     SRC src/SimulinkBlockInformation.cpp
         include/BlockFactory/Simulink/SimulinkBlockInformation.h
+        src/SimulinkBlockInformationImpl.cpp
+        include/BlockFactory/Simulink/Private/SimulinkBlockInformationImpl.h
         src/BlockFactory.cpp
-    LINK_TO BlockFactory::Core shlibpp::shlibpp SimulinkBlockInformationPrivate)
+    LINK_TO BlockFactory::Core shlibpp::shlibpp mxpp)
 add_library(BlockFactory::Simulink ALIAS Simulink)
 
 # Needed to access Simulink C APIs
@@ -49,7 +31,7 @@ target_include_directories(Simulink PUBLIC
 
 # Install S-Function
 install(
-    TARGETS Simulink SimulinkBlockInformationPrivate
+    TARGETS Simulink
     EXPORT BlockFactorySimulinkExport
     DESTINATION mex)
 

--- a/sources/Simulink/include/BlockFactory/Simulink/Private/SimulinkBlockInformationImpl.h
+++ b/sources/Simulink/include/BlockFactory/Simulink/Private/SimulinkBlockInformationImpl.h
@@ -68,6 +68,8 @@ public:
     bool setInputPortMatrixSize(const PortIndex idx, const MatrixSize& size);
     bool setOutputPortVectorSize(const PortIndex idx, const VectorSize& size);
     bool setOutputPortMatrixSize(const PortIndex idx, const MatrixSize& size);
+    int getNrOfInputPortElements(const core::BlockInformation::PortIndex idx) const;
+    int getNrOfOutputPortElements(const core::BlockInformation::PortIndex idx) const;
     PortData getInputPortData(const core::BlockInformation::PortIndex idx) const;
     PortData getOutputPortData(const core::BlockInformation::PortIndex idx) const;
 

--- a/sources/Simulink/include/BlockFactory/Simulink/Private/SimulinkBlockInformationImpl.h
+++ b/sources/Simulink/include/BlockFactory/Simulink/Private/SimulinkBlockInformationImpl.h
@@ -54,6 +54,12 @@ public:
     SimulinkBlockInformationImpl(SimStruct* ss);
     ~SimulinkBlockInformationImpl() = default;
 
+    // =====================
+    // BLOCK OPTIONS METHODS
+    // =====================
+
+    bool optionFromKey(const std::string& key, double& option) const;
+
     // =============
     // PORTS METHODS
     // =============

--- a/sources/Simulink/include/BlockFactory/Simulink/Private/SimulinkBlockInformationImpl.h
+++ b/sources/Simulink/include/BlockFactory/Simulink/Private/SimulinkBlockInformationImpl.h
@@ -68,6 +68,8 @@ public:
     bool setInputPortMatrixSize(const PortIndex idx, const MatrixSize& size);
     bool setOutputPortVectorSize(const PortIndex idx, const VectorSize& size);
     bool setOutputPortMatrixSize(const PortIndex idx, const MatrixSize& size);
+    PortData getInputPortData(const core::BlockInformation::PortIndex idx) const;
+    PortData getOutputPortData(const core::BlockInformation::PortIndex idx) const;
 
     // =================
     // SCALAR PARAMETERS

--- a/sources/Simulink/include/BlockFactory/Simulink/Private/SimulinkBlockInformationImpl.h
+++ b/sources/Simulink/include/BlockFactory/Simulink/Private/SimulinkBlockInformationImpl.h
@@ -20,6 +20,9 @@
 namespace blockfactory {
     namespace mex {
         namespace impl {
+            using ContiguousInputSignalRawPtr = const void*;
+            using NonContiguousInputSignalRawPtr = InputPtrsType;
+            using ContiguousOutputSignalRawPtr = void*;
             class SimulinkBlockInformationImpl;
         } // namespace impl
     } // namespace mex
@@ -78,6 +81,18 @@ public:
     int getNrOfOutputPortElements(const core::BlockInformation::PortIndex idx) const;
     PortData getInputPortData(const core::BlockInformation::PortIndex idx) const;
     PortData getOutputPortData(const core::BlockInformation::PortIndex idx) const;
+    bool isInputPortDynamicallySized(const PortIndex idx) const;
+    bool isOutputPortDynamicallySized(const PortIndex idx) const;
+
+    // ===============
+    // SIGNALS METHODS
+    // ===============
+
+    bool isInputSignalAtIdxContiguous(const PortIndex idx) const;
+    ContiguousInputSignalRawPtr getContiguousSignalRawPtrFromInputPort(const PortIndex idx) const;
+    NonContiguousInputSignalRawPtr
+    getNonContiguousSignalRawPtrFromInputPort(const PortIndex idx) const;
+    ContiguousOutputSignalRawPtr getSignalRawPtrFromOutputPort(const PortIndex idx) const;
 
     // =================
     // SCALAR PARAMETERS

--- a/sources/Simulink/include/BlockFactory/Simulink/SimulinkBlockInformation.h
+++ b/sources/Simulink/include/BlockFactory/Simulink/SimulinkBlockInformation.h
@@ -13,10 +13,6 @@
 #include "BlockFactory/Core/Parameter.h"
 #include "BlockFactory/Core/Signal.h"
 
-// This is a typedef. We could forward declare it but since it might
-// change it is better keeping this include here.
-#include <simstruc.h>
-
 #include <string>
 #include <vector>
 
@@ -28,6 +24,9 @@ namespace blockfactory {
         } // namespace impl
     } // namespace mex
 } // namespace blockfactory
+
+// Forward declare SimStruct
+typedef struct SimStruct_tag SimStruct;
 
 /**
  * @brief Simulink implementation of block information

--- a/sources/Simulink/src/BlockFactory.cpp
+++ b/sources/Simulink/src/BlockFactory.cpp
@@ -161,13 +161,23 @@ static void mdlInitializeSizes(SimStruct* S)
         return;
     }
 
-    for (auto i = 0; i < ssGetNumInputPorts(S); ++i) {
+    // TODO: Investigate about port reusability and local / global scoping:
+    //       https://it.mathworks.com/help/simulink/sfg/sssetinputportoptimopts.html
+    //       https://it.mathworks.com/help/simulink/sfg/sssetoutputportoptimopts.html
+    //       https://it.mathworks.com/help/rtw/ug/s-functions-for-multirate-multitasking-environments.html
+    // TODO: Allow modifying these options through optionFromKey() or similar functionality
+
+    for (int i = 0; i < ssGetNumInputPorts(S); ++i) {
         // Set explicitly the inputs port to be SS_NOT_REUSABLE_AND_GLOBAL (which actually
         // is already the default value). Since the toolbox supports contiguous input signals,
         // this option should not be changed.
         ssSetInputPortOptimOpts(S, i, SS_NOT_REUSABLE_AND_GLOBAL);
         // Set input signals to be allocated in a contiguous memory storage
         ssSetInputPortRequiredContiguous(S, i, true);
+    }
+
+    for (int i = 0; i < ssGetNumOutputPorts(S); ++i) {
+        ssSetOutputPortOptimOpts(S, i, SS_NOT_REUSABLE_AND_GLOBAL);
     }
 
     ssSetNumSampleTimes(S, 1);

--- a/sources/Simulink/src/SimulinkBlockInformation.cpp
+++ b/sources/Simulink/src/SimulinkBlockInformation.cpp
@@ -517,41 +517,11 @@ bool SimulinkBlockInformation::setIOPortsData(const BlockInformation::IOData& io
 core::BlockInformation::PortData
 SimulinkBlockInformation::getInputPortData(const BlockInformation::PortIndex idx) const
 {
-    const core::DataType dt =
-        pImpl->mapSimulinkToPortType(ssGetInputPortDataType(pImpl->simstruct, idx));
-    std::vector<int> portDimension;
-
-    switch (ssGetInputPortNumDimensions(pImpl->simstruct, idx)) {
-        case 1:
-            portDimension = {ssGetInputPortWidth(pImpl->simstruct, idx)};
-            break;
-        case 2: {
-            const auto dims = ssGetInputPortDimensions(pImpl->simstruct, idx);
-            portDimension = {dims[0], dims[1]};
-            break;
-        }
-    }
-
-    return std::make_tuple(idx, portDimension, dt);
+    return pImpl->getInputPortData(idx);
 }
 
 core::BlockInformation::PortData
 SimulinkBlockInformation::getOutputPortData(const BlockInformation::PortIndex idx) const
 {
-    const core::DataType dt =
-        pImpl->mapSimulinkToPortType(ssGetOutputPortDataType(pImpl->simstruct, idx));
-    std::vector<int> portDimension;
-
-    switch (ssGetOutputPortNumDimensions(pImpl->simstruct, idx)) {
-        case 1:
-            portDimension = {ssGetOutputPortWidth(pImpl->simstruct, idx)};
-            break;
-        case 2: {
-            const auto dims = ssGetOutputPortDimensions(pImpl->simstruct, idx);
-            portDimension = {dims[0], dims[1]};
-            break;
-        }
-    }
-
-    return std::make_tuple(idx, portDimension, dt);
+    return pImpl->getOutputPortData(idx);
 }

--- a/sources/Simulink/src/SimulinkBlockInformation.cpp
+++ b/sources/Simulink/src/SimulinkBlockInformation.cpp
@@ -13,6 +13,7 @@
 #include "BlockFactory/Core/Signal.h"
 #include "BlockFactory/Simulink/Private/SimulinkBlockInformationImpl.h"
 
+#include <cassert>
 #include <memory>
 #include <ostream>
 #include <string>
@@ -188,27 +189,33 @@ core::OutputSignalPtr SimulinkBlockInformation::getOutputPortSignal(const PortIn
 core::BlockInformation::MatrixSize
 SimulinkBlockInformation::getInputPortMatrixSize(const PortIndex idx) const
 {
-    if (ssGetInputPortNumDimensions(pImpl->simstruct, idx) < 2) {
+    PortData portData = getInputPortData(idx);
+    PortDimension dims = std::get<Port::Dimensions>(portData);
+
+    if (dims.size() != 2) {
         bfError << "Signal at index " << idx
-                << "does not contain a matrix. Failed to gete its size.";
+                << "does not contain a matrix. Failed to get its size.";
+        assert(dims.size() != 2);
         return {};
     }
 
-    const int_T* sizes = ssGetInputPortDimensions(pImpl->simstruct, idx);
-    return {sizes[0], sizes[1]};
+    return {dims[0], dims[1]};
 }
 
 core::BlockInformation::MatrixSize
 SimulinkBlockInformation::getOutputPortMatrixSize(const PortIndex idx) const
 {
-    if (ssGetOutputPortNumDimensions(pImpl->simstruct, idx) < 2) {
+    PortData portData = getOutputPortData(idx);
+    PortDimension dims = std::get<Port::Dimensions>(portData);
+
+    if (dims.size() != 2) {
         bfError << "Signal at index " << idx
-                << "does not contain a matrix. Failed to gete its size.";
+                << "does not contain a matrix. Failed to get its size.";
+        assert(dims.size() != 2);
         return {};
     }
 
-    const int_T* sizes = ssGetOutputPortDimensions(pImpl->simstruct, idx);
-    return {sizes[0], sizes[1]};
+    return {dims[0], dims[1]};
 }
 
 bool SimulinkBlockInformation::addParameterMetadata(const core::ParameterMetadata& paramMD)

--- a/sources/Simulink/src/SimulinkBlockInformation.cpp
+++ b/sources/Simulink/src/SimulinkBlockInformation.cpp
@@ -50,13 +50,33 @@ bool SimulinkBlockInformation::optionFromKey(const std::string& key, double& opt
 core::BlockInformation::VectorSize
 SimulinkBlockInformation::getInputPortWidth(const PortIndex idx) const
 {
-    return ssGetInputPortWidth(pImpl->simstruct, idx);
+    PortData portData = getInputPortData(idx);
+    PortDimension dims = std::get<Port::Dimensions>(portData);
+
+    if (dims.size() != 1) {
+        bfError << "Signal at index " << idx
+                << "does not contain a vector. Failed to get its size.";
+        assert(dims.size() != 1);
+        return {};
+    }
+
+    return dims[0];
 }
 
 core::BlockInformation::VectorSize
 SimulinkBlockInformation::getOutputPortWidth(const PortIndex idx) const
 {
-    return ssGetOutputPortWidth(pImpl->simstruct, idx);
+    PortData portData = getOutputPortData(idx);
+    PortDimension dims = std::get<Port::Dimensions>(portData);
+
+    if (dims.size() != 1) {
+        bfError << "Signal at index " << idx
+                << "does not contain a vector. Failed to get its size.";
+        assert(dims.size() != 1);
+        return {};
+    }
+
+    return dims[0];
 }
 
 core::InputSignalPtr SimulinkBlockInformation::getInputPortSignal(const PortIndex idx,

--- a/sources/Simulink/src/SimulinkBlockInformation.cpp
+++ b/sources/Simulink/src/SimulinkBlockInformation.cpp
@@ -74,47 +74,50 @@ SimulinkBlockInformation::getOutputPortWidth(const PortIndex idx) const
 }
 
 core::InputSignalPtr SimulinkBlockInformation::getInputPortSignal(const PortIndex idx,
-                                                                  const VectorSize size) const
+                                                                  const VectorSize /*size*/) const
 {
-    // Read if the signal is contiguous or non-contiguous
-    boolean_T isContiguous = ssGetInputPortRequiredContiguous(pImpl->simstruct, idx);
-    core::Signal::DataFormat sigDataFormat = isContiguous
-                                                 ? core::Signal::DataFormat::CONTIGUOUS_ZEROCOPY
-                                                 : core::Signal::DataFormat::NONCONTIGUOUS;
+    // Get the PortData
+    PortData portData = getInputPortData(idx);
+    core::DataType dataType = std::get<Port::DataType>(portData);
 
-    // Check if the signal is dynamically sized (which means that the dimension
-    // cannot be read)
-    bool isDynamicallySized = (ssGetInputPortWidth(pImpl->simstruct, idx) == DYNAMICALLY_SIZED);
-
-    // Note that if the signal is dynamically sized, portWidth is necessary
-    if (isDynamicallySized && size == core::Signal::DynamicSize) {
-        bfError << "Trying to get a dynamically sized signal without specifying its size.";
+    // This can happen only if the Block attempts to get the Signal during the
+    // Block::configureSizeAndPorts step. This has undefined behavior, and it should not
+    // be allowed.
+    if (pImpl->isInputPortDynamicallySized(idx)) {
+        bfError << "The input port " << idx
+                << " has dynamic sizes. Probably the engine hasn't propagated them "
+                << "and the attached signal is not yet available.";
         return {};
     }
 
-    // Read the width of the signal if it is not provided as input and the signal is not
-    // dynamically sized
-    VectorSize signalSize = size;
-    if (!isDynamicallySized && size == core::Signal::DynamicSize) {
-        signalSize = ssGetInputPortWidth(pImpl->simstruct, idx);
-    }
+    // Read if the signal is contiguous or non-contiguous
+    boolean_T isContiguous = pImpl->isInputSignalAtIdxContiguous(idx);
+    auto signalDataFormat = isContiguous ? core::Signal::DataFormat::CONTIGUOUS_ZEROCOPY
+                                         : core::Signal::DataFormat::NONCONTIGUOUS;
 
-    // Get the data type of the Signal if set (default: double)
-    DTypeId dataType = ssGetInputPortDataType(pImpl->simstruct, idx);
+    // Read the number of expected elements. This will match the buffer size of
+    // the associated Signal object.
+    int nrOfElements = pImpl->getNrOfInputPortElements(idx);
 
-    switch (sigDataFormat) {
+    switch (signalDataFormat) {
         case core::Signal::DataFormat::CONTIGUOUS_ZEROCOPY: {
+            // Get the buffer pointer from Simulink
+            auto signalRawPtr = pImpl->getContiguousSignalRawPtrFromInputPort(idx);
+            if (!signalRawPtr) {
+                bfError << "Failed to get input signal at index " << idx << ".";
+            }
+
             // Initialize the signal
-            auto signal =
-                std::make_shared<core::Signal>(core::Signal::DataFormat::CONTIGUOUS_ZEROCOPY,
-                                               pImpl->mapSimulinkToPortType(dataType));
-            signal->setWidth(signalSize);
+            auto signal = std::make_shared<core::Signal>(
+                core::Signal::DataFormat::CONTIGUOUS_ZEROCOPY, dataType);
+
+            // Set the width
+            signal->setWidth(static_cast<unsigned>(nrOfElements));
 
             // Initialize signal's data
-            if (!signal->initializeBufferFromContiguousZeroCopy(
-                    ssGetInputPortSignal(pImpl->simstruct, idx))) {
-                bfError << "Failed to inititialize CONTIGUOUS_ZEROCOPY signal at index " << idx
-                        << ".";
+            if (!signal->initializeBufferFromContiguousZeroCopy(signalRawPtr)) {
+                bfError << "Failed to initialize CONTIGUOUS_ZEROCOPY signal connected to "
+                        << "input port at index " << idx << ".";
                 return {};
             }
 
@@ -124,18 +127,26 @@ core::InputSignalPtr SimulinkBlockInformation::getInputPortSignal(const PortInde
                 return {};
             }
 
-            return signal;
+            return std::move(signal);
         }
         case core::Signal::DataFormat::NONCONTIGUOUS: {
+            // Get the buffer pointer from Simulink
+            auto signalRawPtr = pImpl->getNonContiguousSignalRawPtrFromInputPort(idx);
+            if (!signalRawPtr) {
+                bfError << "Failed to get input signal at index " << idx << ".";
+            }
+
             // Initialize the signal
-            auto signal = std::make_shared<core::Signal>(core::Signal::DataFormat::NONCONTIGUOUS,
-                                                         pImpl->mapSimulinkToPortType(dataType));
-            signal->setWidth(signalSize);
+            auto signal =
+                std::make_shared<core::Signal>(core::Signal::DataFormat::NONCONTIGUOUS, dataType);
+
+            // Set the width
+            signal->setWidth(nrOfElements);
 
             // Initialize signal's data
-            InputPtrsType port = ssGetInputPortSignalPtrs(pImpl->simstruct, idx);
-            if (!signal->initializeBufferFromNonContiguous(static_cast<const void* const*>(port))) {
-                bfError << "Failed to inititialize NONCONTIGUOUS signal at index " << idx << ".";
+            if (!signal->initializeBufferFromNonContiguous(signalRawPtr)) {
+                bfError << "Failed to initialize NONCONTIGUOUS signal connected to "
+                        << "input port at index " << idx << ".";
                 return {};
             }
 
@@ -145,13 +156,13 @@ core::InputSignalPtr SimulinkBlockInformation::getInputPortSignal(const PortInde
                 return {};
             }
 
-            return signal;
+            return std::move(signal);
         }
         case core::Signal::DataFormat::CONTIGUOUS: {
             bfError << "Failed to inititialize CONTIGUOUS signal at index " << idx << "."
                     << std::endl
                     << "CONTIGUOUS input signals are not yet supported. "
-                    << "Use CONTIGUOUS_ZEROCOPY instead.";
+                    << "Use CONTIGUOUS_ZEROCOPY instead, they are more efficient.";
             return {};
         }
     }
@@ -160,40 +171,49 @@ core::InputSignalPtr SimulinkBlockInformation::getInputPortSignal(const PortInde
 }
 
 core::OutputSignalPtr SimulinkBlockInformation::getOutputPortSignal(const PortIndex idx,
-                                                                    const VectorSize size) const
+                                                                    const VectorSize /*size*/) const
 {
-    // Check if the signal is dynamically sized (which means that the dimension
-    // cannot be read)
-    bool isDynamicallySized = (ssGetOutputPortWidth(pImpl->simstruct, idx) == DYNAMICALLY_SIZED);
+    // Get the PortData
+    PortData portData = getOutputPortData(idx);
+    core::DataType dataType = std::get<Port::DataType>(portData);
 
-    // Note that if the signal is dynamically sized, portWidth is necessary
-    if (isDynamicallySized && size == core::Signal::DynamicSize) {
-        bfError << "Trying to get a dynamically sized signal without specifying its size.";
+    // This can happen only if the Block attempts to get the Signal during the
+    // Block::configureSizeAndPorts step. This has undefined behavior, and it should not
+    // be allowed.
+    if (pImpl->isOutputPortDynamicallySized(idx)) {
+        bfError << "The output port " << idx
+                << " has dynamic sizes. Probably the engine hasn't propagated them "
+                << "and the attached signal is not yet available.";
         return {};
     }
 
-    // Read the width of the signal if it is not provided as input and the signal is not
-    // dynamically sized
-    VectorSize signalSize = size;
-    if (!isDynamicallySized && size == core::Signal::DynamicSize) {
-        signalSize = ssGetOutputPortWidth(pImpl->simstruct, idx);
+    // Read the number of expected elements. This will match the buffer size of
+    // the associated Signal object.
+    int nrOfElements = pImpl->getNrOfOutputPortElements(idx);
+
+    // Get the buffer pointer from Simulink
+    auto signalRawPtr = pImpl->getSignalRawPtrFromOutputPort(idx);
+    if (!signalRawPtr) {
+        bfError << "Failed to get output signal at index " << idx << ".";
     }
 
-    // Get the data type of the Signal if set (default: double)
-    DTypeId dataType = ssGetOutputPortDataType(pImpl->simstruct, idx);
+    // Initialize the signal
+    auto signal =
+        std::make_shared<core::Signal>(core::Signal::DataFormat::CONTIGUOUS_ZEROCOPY, dataType);
 
-    auto signal = std::make_shared<core::Signal>(core::Signal::DataFormat::CONTIGUOUS_ZEROCOPY,
-                                                 pImpl->mapSimulinkToPortType(dataType));
-    signal->setWidth(signalSize);
+    // Set the width
+    signal->setWidth(static_cast<unsigned>(nrOfElements));
 
-    if (!signal->initializeBufferFromContiguousZeroCopy(
-            ssGetOutputPortSignal(pImpl->simstruct, idx))) {
-        bfError << "Failed to inititialize CONTIGUOUS_ZEROCOPY signal at index " << idx << ".";
+    // Initialize signal's data
+    if (!signal->initializeBufferFromContiguousZeroCopy(signalRawPtr)) {
+        bfError << "Failed to initialize CONTIGUOUS_ZEROCOPY signal connected to "
+                << "output port at index " << idx << ".";
         return {};
     }
 
+    // Check signal validity
     if (!signal->isValid()) {
-        bfError << "Output signal at index " << idx << " is not valid.";
+        bfError << "Input signal at index " << idx << " is not valid.";
         return {};
     }
 

--- a/sources/Simulink/src/SimulinkBlockInformation.cpp
+++ b/sources/Simulink/src/SimulinkBlockInformation.cpp
@@ -35,13 +35,7 @@ SimulinkBlockInformation::~SimulinkBlockInformation() = default;
 
 bool SimulinkBlockInformation::optionFromKey(const std::string& key, double& option) const
 {
-    if (key == core::BlockOptionPrioritizeOrder) {
-        option = SS_OPTION_PLACE_ASAP;
-        return true;
-    }
-
-    bfError << "Unrecognized block option.";
-    return false;
+    return pImpl->optionFromKey(key, option);
 }
 
 // PORT INFORMATION GETTERS

--- a/sources/Simulink/src/SimulinkBlockInformationImpl.cpp
+++ b/sources/Simulink/src/SimulinkBlockInformationImpl.cpp
@@ -334,6 +334,63 @@ SimulinkBlockInformationImpl::getOutputPortData(const BlockInformation::PortInde
     return std::make_tuple(idx, portDimension, dt);
 }
 
+bool SimulinkBlockInformationImpl::isInputPortDynamicallySized(const PortIndex idx) const
+{
+    PortData portData = getInputPortData(idx);
+    BlockInformation::PortDimension dimensions =
+        std::get<BlockInformation::Port::Dimensions>(portData);
+
+    for (auto dim : dimensions) {
+        if (dim == core::Signal::DynamicSize) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool SimulinkBlockInformationImpl::isOutputPortDynamicallySized(const PortIndex idx) const
+{
+    PortData portData = getOutputPortData(idx);
+    BlockInformation::PortDimension dimensions =
+        std::get<BlockInformation::Port::Dimensions>(portData);
+
+    for (auto dim : dimensions) {
+        if (dim == core::Signal::DynamicSize) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool SimulinkBlockInformationImpl::isInputSignalAtIdxContiguous(
+    const SimulinkBlockInformationImpl::PortIndex idx) const
+{
+    return ssGetInputPortRequiredContiguous(simstruct, idx);
+}
+
+ContiguousInputSignalRawPtr
+SimulinkBlockInformationImpl::getContiguousSignalRawPtrFromInputPort(const PortIndex idx) const
+{
+    auto ptr = ssGetInputPortSignal(simstruct, idx);
+    return idx >= ssGetNumInputPorts(simstruct) ? nullptr : ptr;
+}
+
+NonContiguousInputSignalRawPtr
+SimulinkBlockInformationImpl::getNonContiguousSignalRawPtrFromInputPort(const PortIndex idx) const
+{
+    auto ptr = ssGetInputPortSignalPtrs(simstruct, idx);
+    return idx >= ssGetNumInputPorts(simstruct) ? nullptr : ptr;
+}
+
+ContiguousOutputSignalRawPtr
+SimulinkBlockInformationImpl::getSignalRawPtrFromOutputPort(const PortIndex idx) const
+{
+    auto ptr = ssGetOutputPortSignal(simstruct, idx);
+    return idx >= ssGetNumOutputPorts(simstruct) ? nullptr : ptr;
+}
+
 // =================
 // SCALAR PARAMETERS
 // =================

--- a/sources/Simulink/src/SimulinkBlockInformationImpl.cpp
+++ b/sources/Simulink/src/SimulinkBlockInformationImpl.cpp
@@ -11,6 +11,7 @@
 #include "BlockFactory/Core/Parameter.h"
 #include "BlockFactory/Core/Signal.h"
 
+#include <cassert>
 #include <simstruc.h>
 
 using namespace blockfactory::core;
@@ -230,6 +231,64 @@ bool SimulinkBlockInformationImpl::setOutputPortMatrixSize(const PortIndex idx,
     }
 
     return ssSetOutputPortMatrixDimensions(simstruct, idx, size.first, size.second);
+}
+
+SimulinkBlockInformationImpl::PortData
+SimulinkBlockInformationImpl::getInputPortData(const BlockInformation::PortIndex idx) const
+{
+    std::vector<int> portDimension;
+
+    const core::DataType dt = mapSimulinkToPortType(ssGetInputPortDataType(simstruct, idx));
+
+    switch (ssGetInputPortNumDimensions(simstruct, idx)) {
+        case 1: {
+            auto width = ssGetInputPortWidth(simstruct, idx);
+            width == DYNAMICALLY_SIZED ? width = core::Signal::DynamicSize : true;
+            portDimension = {width};
+            break;
+        }
+        case 2: {
+            auto dims = ssGetInputPortDimensions(simstruct, idx);
+            dims[0] == DYNAMICALLY_SIZED ? dims[0] = core::Signal::DynamicSize : true;
+            dims[1] == DYNAMICALLY_SIZED ? dims[1] = core::Signal::DynamicSize : true;
+            portDimension = {dims[0], dims[1]};
+            break;
+        }
+        default:
+            bfError << "Unsupported number of port dimensions for port at index " << idx;
+            assert(false);
+    }
+
+    return std::make_tuple(idx, portDimension, dt);
+}
+
+SimulinkBlockInformationImpl::PortData
+SimulinkBlockInformationImpl::getOutputPortData(const BlockInformation::PortIndex idx) const
+{
+    std::vector<int> portDimension;
+
+    const core::DataType dt = mapSimulinkToPortType(ssGetOutputPortDataType(simstruct, idx));
+
+    switch (ssGetOutputPortNumDimensions(simstruct, idx)) {
+        case 1: {
+            auto width = ssGetOutputPortWidth(simstruct, idx);
+            width == DYNAMICALLY_SIZED ? width = core::Signal::DynamicSize : true;
+            portDimension = {width};
+            break;
+        }
+        case 2: {
+            auto dims = ssGetOutputPortDimensions(simstruct, idx);
+            dims[0] == DYNAMICALLY_SIZED ? dims[0] = core::Signal::DynamicSize : true;
+            dims[1] == DYNAMICALLY_SIZED ? dims[1] = core::Signal::DynamicSize : true;
+            portDimension = {dims[0], dims[1]};
+            break;
+        }
+        default:
+            bfError << "Unsupported number of port dimensions for port at index " << idx;
+            assert(false);
+    }
+
+    return std::make_tuple(idx, portDimension, dt);
 }
 
 // =================

--- a/sources/Simulink/src/SimulinkBlockInformationImpl.cpp
+++ b/sources/Simulink/src/SimulinkBlockInformationImpl.cpp
@@ -21,6 +21,17 @@ SimulinkBlockInformationImpl::SimulinkBlockInformationImpl(SimStruct* ss)
     : simstruct(ss)
 {}
 
+bool SimulinkBlockInformationImpl::optionFromKey(const std::string& key, double& option) const
+{
+    if (key == core::BlockOptionPrioritizeOrder) {
+        option = SS_OPTION_PLACE_ASAP;
+        return true;
+    }
+
+    bfError << "Unrecognized block option.";
+    return false;
+}
+
 DataType SimulinkBlockInformationImpl::mapSimulinkToPortType(const DTypeId typeId) const
 {
     switch (typeId) {

--- a/sources/Simulink/src/SimulinkBlockInformationImpl.cpp
+++ b/sources/Simulink/src/SimulinkBlockInformationImpl.cpp
@@ -233,6 +233,38 @@ bool SimulinkBlockInformationImpl::setOutputPortMatrixSize(const PortIndex idx,
     return ssSetOutputPortMatrixDimensions(simstruct, idx, size.first, size.second);
 }
 
+int SimulinkBlockInformationImpl::getNrOfInputPortElements(
+    const BlockInformation::PortIndex idx) const
+{
+    PortData portData = getInputPortData(idx);
+    BlockInformation::PortDimension dimensions =
+        std::get<BlockInformation::Port::Dimensions>(portData);
+
+    int nrOfElements = 1;
+    for (int dim : dimensions) {
+        dim == Signal::DynamicSize ? dim = 0 : true;
+        nrOfElements *= dim;
+    }
+
+    return nrOfElements;
+}
+
+int SimulinkBlockInformationImpl::getNrOfOutputPortElements(
+    const BlockInformation::PortIndex idx) const
+{
+    PortData portData = getOutputPortData(idx);
+    BlockInformation::PortDimension dimensions =
+        std::get<BlockInformation::Port::Dimensions>(portData);
+
+    int nrOfElements = 1;
+    for (int dim : dimensions) {
+        dim == Signal::DynamicSize ? dim = 0 : true;
+        nrOfElements *= dim;
+    }
+
+    return nrOfElements;
+}
+
 SimulinkBlockInformationImpl::PortData
 SimulinkBlockInformationImpl::getInputPortData(const BlockInformation::PortIndex idx) const
 {


### PR DESCRIPTION
- All the calls to Simulink API have been moved to the private class.
- Since we support only 1D and 2D signals, the `BlockInformation::get{In,Out}putPortWidth` should work only for 1D signals, analogously to the `BlockInformation::get{In,Out}putPortMatrixSize` that works only for 2D signals. I'm open to change the names of the method of the interface is the current ones are not clear enough.
- Getting Input / Output signals from the blocks should be safer now, the methods have been refactored and the checks now cover more cases.

I want to change the following methods in the `BlockInformation` interface:

```cpp
virtual blockfactory::core::InputSignalPtr
    getInputPortSignal(const PortIndex idx, const VectorSize size = -1) const = 0;
virtual blockfactory::core::OutputSignalPtr
    getOutputPortSignal(const PortIndex idx, const VectorSize size = -1) const = 0;
```

and remove the `size` parameter. However, since this will affect also the SimulinkCoder implementation, I will open a new PR with also the rationale about it.