### PR TITLE
Remove references to removed methods

### DIFF
--- a/sources/Core/include/BlockFactory/Core/Block.h
+++ b/sources/Core/include/BlockFactory/Core/Block.h
@@ -231,8 +231,7 @@ public:
      *
      * @param blockInfo The pointer to a BlockInformation object.
      * @return True if the block was configured successfully, false otherwise.
-     * @see core::BlockInformation::setNumberOfInputPorts,
-     *      core::BlockInformation::setInputPortVectorSize
+     * @see core::BlockInformation::setIOPortsData
      */
     virtual bool configureSizeAndPorts(BlockInformation* blockInfo);
 

--- a/sources/Core/include/BlockFactory/Core/BlockInformation.h
+++ b/sources/Core/include/BlockFactory/Core/BlockInformation.h
@@ -137,10 +137,6 @@ public:
      * @param ioData The structure containing I/O ports data.
      * @return True for success, false otherwise.
      *
-     * @see core::BlockInformation::setNumberOfInputPorts,
-     *      core::BlockInformation::setInputPortVectorSize,
-     *      core::BlockInformation::setInputPortMatrixSize,
-     *      core::BlockInformation::setInputPortDataType
      * @note This method should also automatically set the number of inputs and outputs.
      */
     virtual bool setIOPortsData(const IOData& ioData) = 0;


### PR DESCRIPTION
The referenced methods were removed in https://github.com/robotology/wb-toolbox/pull/114 .