### PR TITLE
Added block identifier support

### DIFF
--- a/example/matlab/AutogenerationExample_grt_rtw/AutogenerationExample.cpp
+++ b/example/matlab/AutogenerationExample_grt_rtw/AutogenerationExample.cpp
@@ -114,6 +114,9 @@ void AutogenerationExampleModelClass::initialize()
             blockfactory::core::ParameterMetadata(
                 blockfactory::core::ParameterType::STRING, 0.0, 1.0, 1.0, "className"));
 
+        // Store the block name
+        blockInfo->setUniqueBlockName("AutogenerationExample/Signal Math");
+
         // Store the parameters in the CoderBlockInformation object
         blockInfo->storeRTWParameters(params);
 

--- a/matlab/BlockFactory.tlc
+++ b/matlab/BlockFactory.tlc
@@ -136,6 +136,7 @@
     %assign numberOfParameters = SFcnParamSettings[0].numberOfParameters
     %assign className = SFcnParamSettings[0].className
     %assign libName = SFcnParamSettings[0].libName
+    %assign blockUniqueName = SFcnParamSettings[0].blockUniqueName
 
     %foreach i = numberOfParameters
 
@@ -174,6 +175,9 @@
     }
     %endif
     %endforeach
+
+    // Store the block name
+    blockInfo->setUniqueBlockName("%<blockUniqueName>");
 
     // Store the parameters in the CoderBlockInformation object
     blockInfo->storeRTWParameters(params);

--- a/sources/Core/include/BlockFactory/Core/Block.h
+++ b/sources/Core/include/BlockFactory/Core/Block.h
@@ -92,6 +92,14 @@ public:
     virtual ~Block() = default;
 
     /**
+     * @brief Get the unique name of the block instance
+     *
+     * @param blockInfo The pointer to a BlockInformation object.
+     * @return The unique name of the block instance if it was set, an empty string otherwise.
+     */
+    std::string getUniqueName(const BlockInformation* blockInfo) const;
+
+    /**
      * @brief Number of parameters of core::Block
      *
      * Static variable matching Block::numberOfParameters. It might be useful to define

--- a/sources/Core/include/BlockFactory/Core/BlockInformation.h
+++ b/sources/Core/include/BlockFactory/Core/BlockInformation.h
@@ -58,6 +58,17 @@ public:
     BlockInformation() = default;
     virtual ~BlockInformation() = default;
 
+    /**
+     * @brief Get the unique name of the block instance
+     *
+     * Retrive from the engine the unique name of the block. A typical example is the scoped
+     * name of the block that takes into account its location in the model hierarchy.
+     *
+     * @param[out] blockUniqueName The unique name of the block instance.
+     * @return True for success, false otherwise.
+     */
+    virtual bool getUniqueName(std::string& blockUniqueName) const = 0;
+
     // =====================
     // BLOCK OPTIONS METHODS
     // =====================

--- a/sources/Core/src/Block.cpp
+++ b/sources/Core/src/Block.cpp
@@ -15,6 +15,13 @@
 
 using namespace blockfactory::core;
 
+std::string Block::getUniqueName(const BlockInformation* blockInfo) const
+{
+    std::string blockUniqueName;
+    blockInfo->getUniqueName(blockUniqueName);
+    return blockUniqueName;
+}
+
 unsigned Block::numberOfParameters()
 {
     return Block::NumberOfParameters;

--- a/sources/Simulink/include/BlockFactory/Simulink/Private/SimulinkBlockInformationImpl.h
+++ b/sources/Simulink/include/BlockFactory/Simulink/Private/SimulinkBlockInformationImpl.h
@@ -57,6 +57,8 @@ public:
     SimulinkBlockInformationImpl(SimStruct* ss);
     ~SimulinkBlockInformationImpl() = default;
 
+    bool getUniqueName(std::string& blockUniqueName) const;
+
     // =====================
     // BLOCK OPTIONS METHODS
     // =====================

--- a/sources/Simulink/include/BlockFactory/Simulink/SimulinkBlockInformation.h
+++ b/sources/Simulink/include/BlockFactory/Simulink/SimulinkBlockInformation.h
@@ -47,6 +47,7 @@ public:
     SimulinkBlockInformation(SimStruct* simstruct);
     ~SimulinkBlockInformation() override;
 
+    bool getUniqueName(std::string& blockUniqueName) const override;
     bool optionFromKey(const std::string& key, double& option) const override;
     bool addParameterMetadata(const core::ParameterMetadata& paramMD) override;
     bool parseParameters(core::Parameters& parameters) override;

--- a/sources/Simulink/src/BlockFactory.cpp
+++ b/sources/Simulink/src/BlockFactory.cpp
@@ -748,7 +748,9 @@ bool writeParameterToRTW(const blockfactory::core::Parameter<std::string> param,
     }
 }
 
-bool writeRTW(SimStruct* S, const blockfactory::core::Parameters& params)
+bool writeRTW(SimStruct* S,
+              const std::string& blockUniqueName,
+              const blockfactory::core::Parameters& params)
 {
     // RTW Parameters record metadata
     // ==============================
@@ -769,10 +771,13 @@ bool writeRTW(SimStruct* S, const blockfactory::core::Parameters& params)
 
     // Create the record
     ssWriteRTWParamSettings(S,
-                            3,
+                            4,
                             SSWRITE_VALUE_NUM,
                             "numberOfParameters",
                             static_cast<real_T>(numberOfParameters),
+                            SSWRITE_VALUE_QSTR,
+                            "blockUniqueName",
+                            blockUniqueName.c_str(),
                             SSWRITE_VALUE_QSTR,
                             "className",
                             className.c_str(),
@@ -816,6 +821,8 @@ static void mdlRTW(SimStruct* S)
         // Get the block object from the PWork
         blockfactory::core::Block* block =
             static_cast<blockfactory::core::Block*>(ssGetPWorkValue(S, 0));
+        // Get the SimulinkBlockInformation object from the PWork
+        auto* blockInfo = static_cast<blockfactory::core::BlockInformation*>(ssGetPWorkValue(S, 1));
 
         bool ok;
         blockfactory::core::Parameters params;
@@ -836,8 +843,12 @@ static void mdlRTW(SimStruct* S)
             return;
         }
 
+        // Get the block object name
+        std::string blockUniqueName;
+        blockInfo->getUniqueName(blockUniqueName);
+
         // Use parameters metadata to populate the rtw file used by the coder
-        ok = writeRTW(S, params);
+        ok = writeRTW(S, blockUniqueName, params);
         catchLogMessages(ok, S);
         if (!ok) {
             bfError << "Failed to write parameters to the RTW file during the code "

--- a/sources/Simulink/src/BlockFactory.cpp
+++ b/sources/Simulink/src/BlockFactory.cpp
@@ -274,11 +274,10 @@ static void mdlUpdate(SimStruct* S, int_T tid)
     }
 
     // Get the Block object
-    blockfactory::core::Block* block =
-        static_cast<blockfactory::core::Block*>(ssGetPWorkValue(S, 0));
+    auto* block = static_cast<blockfactory::core::Block*>(ssGetPWorkValue(S, 0));
+
     // Get the SimulinkBlockInformation object
-    blockfactory::mex::SimulinkBlockInformation* blockInfo;
-    blockInfo = static_cast<blockfactory::mex::SimulinkBlockInformation*>(ssGetPWorkValue(S, 1));
+    auto* blockInfo = static_cast<blockfactory::core::BlockInformation*>(ssGetPWorkValue(S, 1));
 
     if (!block || !blockInfo) {
         bfError << "Failed to get pointers from the PWork vector.";
@@ -304,11 +303,10 @@ static void mdlInitializeConditions(SimStruct* S)
     }
 
     // Get the Block object
-    blockfactory::core::Block* block =
-        static_cast<blockfactory::core::Block*>(ssGetPWorkValue(S, 0));
+    auto* block = static_cast<blockfactory::core::Block*>(ssGetPWorkValue(S, 0));
+
     // Get the SimulinkBlockInformation object
-    blockfactory::mex::SimulinkBlockInformation* blockInfo;
-    blockInfo = static_cast<blockfactory::mex::SimulinkBlockInformation*>(ssGetPWorkValue(S, 1));
+    auto* blockInfo = static_cast<blockfactory::core::BlockInformation*>(ssGetPWorkValue(S, 1));
 
     if (!block || !blockInfo) {
         bfError << "Failed to get pointers from the PWork vector.";
@@ -344,11 +342,10 @@ static void mdlOutputs(SimStruct* S, int_T tid)
     }
 
     // Get the Block object
-    blockfactory::core::Block* block =
-        static_cast<blockfactory::core::Block*>(ssGetPWorkValue(S, 0));
+    auto* block = static_cast<blockfactory::core::Block*>(ssGetPWorkValue(S, 0));
+
     // Get the SimulinkBlockInformation object
-    blockfactory::mex::SimulinkBlockInformation* blockInfo;
-    blockInfo = static_cast<blockfactory::mex::SimulinkBlockInformation*>(ssGetPWorkValue(S, 1));
+    auto* blockInfo = static_cast<blockfactory::core::BlockInformation*>(ssGetPWorkValue(S, 1));
 
     if (!block || !blockInfo) {
         bfError << "Failed to get pointers from the PWork vector.";
@@ -374,11 +371,10 @@ static void mdlTerminate(SimStruct* S)
     }
 
     // Get the Block object
-    blockfactory::core::Block* block =
-        static_cast<blockfactory::core::Block*>(ssGetPWorkValue(S, 0));
+    auto* block = static_cast<blockfactory::core::Block*>(ssGetPWorkValue(S, 0));
+
     // Get the SimulinkBlockInformation object
-    blockfactory::mex::SimulinkBlockInformation* blockInfo;
-    blockInfo = static_cast<blockfactory::mex::SimulinkBlockInformation*>(ssGetPWorkValue(S, 1));
+    auto* blockInfo = static_cast<blockfactory::core::BlockInformation*>(ssGetPWorkValue(S, 1));
 
     // Get the factory object from the singleton
     auto factory = getFactoryForThisBlockType(S);
@@ -819,8 +815,8 @@ static void mdlRTW(SimStruct* S)
     if (ssGetNumPWork(S) > 0 && ssGetPWork(S)) {
 
         // Get the block object from the PWork
-        blockfactory::core::Block* block =
-            static_cast<blockfactory::core::Block*>(ssGetPWorkValue(S, 0));
+        auto* block = static_cast<blockfactory::core::Block*>(ssGetPWorkValue(S, 0));
+
         // Get the SimulinkBlockInformation object from the PWork
         auto* blockInfo = static_cast<blockfactory::core::BlockInformation*>(ssGetPWorkValue(S, 1));
 

--- a/sources/Simulink/src/SimulinkBlockInformation.cpp
+++ b/sources/Simulink/src/SimulinkBlockInformation.cpp
@@ -28,6 +28,11 @@ SimulinkBlockInformation::SimulinkBlockInformation(SimStruct* S)
     : pImpl(std::make_unique<impl::SimulinkBlockInformationImpl>(S))
 {}
 
+bool SimulinkBlockInformation::getUniqueName(std::string& blockUniqueName) const
+{
+    return pImpl->getUniqueName(blockUniqueName);
+}
+
 SimulinkBlockInformation::~SimulinkBlockInformation() = default;
 
 // BLOCK OPTIONS METHODS

--- a/sources/Simulink/src/SimulinkBlockInformationImpl.cpp
+++ b/sources/Simulink/src/SimulinkBlockInformationImpl.cpp
@@ -21,6 +21,12 @@ SimulinkBlockInformationImpl::SimulinkBlockInformationImpl(SimStruct* ss)
     : simstruct(ss)
 {}
 
+bool SimulinkBlockInformationImpl::getUniqueName(std::string& blockUniqueName) const
+{
+    blockUniqueName = ssGetPath(simstruct);
+    return true;
+}
+
 bool SimulinkBlockInformationImpl::optionFromKey(const std::string& key, double& option) const
 {
     if (key == core::BlockOptionPrioritizeOrder) {

--- a/sources/SimulinkCoder/include/BlockFactory/SimulinkCoder/CoderBlockInformation.h
+++ b/sources/SimulinkCoder/include/BlockFactory/SimulinkCoder/CoderBlockInformation.h
@@ -36,6 +36,8 @@ public:
     CoderBlockInformation();
     ~CoderBlockInformation() override;
 
+    bool getUniqueName(std::string& blockUniqueName) const override;
+
     // BLOCK OPTIONS METHODS
     // =====================
 
@@ -72,6 +74,7 @@ public:
     // METHODS OUTSIDE THE INTERFACE
     // =============================
 
+    bool setUniqueBlockName(const std::string& blockUniqueName);
     bool storeRTWParameters(const core::Parameters& parameters);
     bool setInputPort(const core::Port::Info& portInfo, void* signalAddress);
     bool setOutputPort(const core::Port::Info& portInfo, void* signalAddress);

--- a/sources/SimulinkCoder/src/CoderBlockInformation.cpp
+++ b/sources/SimulinkCoder/src/CoderBlockInformation.cpp
@@ -33,7 +33,7 @@ class CoderBlockInformation::impl
 public:
     std::vector<core::ParameterMetadata> paramsMetadata;
 
-    std::string confBlockName;
+    std::string blockUniqueName;
     core::Parameters parametersFromRTW;
 
     using IndexToPortAndSignalDataMap = std::unordered_map<core::Port::Index, PortAndSignalData>;
@@ -70,6 +70,12 @@ bool CoderBlockInformation::impl::outputPortAtIndexExists(const core::Port::Inde
 CoderBlockInformation::CoderBlockInformation()
     : pImpl(std::make_unique<CoderBlockInformation::impl>())
 {}
+
+bool CoderBlockInformation::getUniqueName(std::string& blockUniqueName) const
+{
+    blockUniqueName = pImpl->blockUniqueName;
+    return true;
+}
 
 CoderBlockInformation::~CoderBlockInformation() = default;
 
@@ -172,6 +178,12 @@ core::OutputSignalPtr CoderBlockInformation::getOutputPortSignal(const core::Por
     }
 
     return signal;
+}
+
+bool CoderBlockInformation::setUniqueBlockName(const std::string& blockUniqueName)
+{
+    pImpl->blockUniqueName = blockUniqueName;
+    return true;
 }
 
 core::Port::Size::Matrix


### PR DESCRIPTION
This PR adds preliminary support to set a string identifier to each block. This might be useful to know directly from the `core::Block` interface which simulation block is associated to the block object.

Currently there is no check that this identifier is unique. In the Simulink implementation the block name matches its absolute path inside the Simulink model, and this information is also transferred to the autogenerated source passing through the TLC file.

This addition opens the possibility to create a sort of database in the autogenerated sources and access the `core::Block` object from its name. In this way, for instance, the block mask parameters could be accessed and edited, providing a possible solution to changing them after the code has been generated (right now they are hardcoded in the sources from the TLC).

Closes #16  