### PR TITLE
Fix for interference with Windows.h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+cmake-build*/
+build/
+install/
+.vscode/
+.idea/
 *.d
 *.slo
 *.lo
@@ -31,4 +36,3 @@ slprj
 *.tmw
 *.dmr
 *.mk
-

--- a/sources/Core/include/BlockFactory/Core/Log.h
+++ b/sources/Core/include/BlockFactory/Core/Log.h
@@ -22,13 +22,13 @@
 #ifndef bfError
 #define bfError                                                 \
     blockfactory::core::Log::getSingleton().getLogStringStream( \
-        blockfactory::core::Log::Type::ERROR, __FILE__, __LINE__, __FUNCTION__)
+        blockfactory::core::Log::Type::LOG_TYPE_ERROR, __FILE__, __LINE__, __FUNCTION__)
 #endif
 
 #ifndef bfWarning
 #define bfWarning                                               \
     blockfactory::core::Log::getSingleton().getLogStringStream( \
-        blockfactory::core::Log::Type::WARNING, __FILE__, __LINE__, __FUNCTION__)
+        blockfactory::core::Log::Type::LOG_TYPE_ERROR, __FILE__, __LINE__, __FUNCTION__)
 #endif
 
 namespace blockfactory {
@@ -47,8 +47,8 @@ class blockfactory::core::Log
 public:
     enum class Type
     {
-        ERROR,
-        WARNING
+        LOG_TYPE_ERROR,
+        LOG_TYPE_WARNING
     };
 
     enum class Verbosity

--- a/sources/Core/src/Log.cpp
+++ b/sources/Core/src/Log.cpp
@@ -43,24 +43,24 @@ std::stringstream& Log::getLogStringStream(const Log::Type& type,
     switch (pImpl->verbosity) {
         case Log::Verbosity::RELEASE:
             switch (type) {
-                case Log::Type::ERROR:
+                case Log::Type::LOG_TYPE_ERROR:
                     pImpl->errorsSStream.emplace_back(new std::stringstream);
                     return *pImpl->errorsSStream.back();
-                case Log::Type::WARNING:
+                case Log::Type::LOG_TYPE_WARNING:
                     pImpl->warningsSStream.emplace_back(new std::stringstream);
                     return *pImpl->warningsSStream.back();
             }
             break;
         case Log::Verbosity::DEBUG:
             switch (type) {
-                case Log::Type::ERROR: {
+                case Log::Type::LOG_TYPE_ERROR: {
                     pImpl->errorsSStream.emplace_back(new std::stringstream);
                     auto& ss = *pImpl->errorsSStream.back();
                     ss << std::endl
                        << file << "@" << function << ":" << std::to_string(line) << std::endl;
                     return ss;
                 }
-                case Log::Type::WARNING: {
+                case Log::Type::LOG_TYPE_WARNING: {
                     pImpl->warningsSStream.emplace_back(new std::stringstream);
                     auto& ss = *pImpl->warningsSStream.back();
                     ss << std::endl


### PR DESCRIPTION
In the frame of my development of a SimConnect Toolbox library, I needed to include Windows.h and got an issue due to the naming of blockfactory::core::Log::Type.

Now I fully agree that Windows.h is broken here, but I currently don't see any other way than fixing the issue by renaming the enum value names.

This pull-request contains a proposal.

On top of this change I suggest also some additional entries for the git ignore file. They are helpfuly when using CLion or Visual Studio Code.