### PR TITLE
Add blockfactory-exists command line tool

### DIFF
--- a/sources/CMakeLists.txt
+++ b/sources/CMakeLists.txt
@@ -9,6 +9,8 @@ if(USES_MATLAB)
     add_subdirectory(Simulink)
 endif()
 
+add_subdirectory(Tools)
+
 # ========================
 # MAIN BLOCKFACTORY TARGET
 # ========================
@@ -16,7 +18,7 @@ endif()
 # Dummy target
 add_library(BlockFactory INTERFACE)
 
-set(BLOCKFACTORY_DEPENDENCIES BlockFactoryCore BlockFactorySimulinkCoder)
+set(BLOCKFACTORY_DEPENDENCIES BlockFactoryCore BlockFactorySimulinkCoder BlockFactoryTools)
 if (USES_MATLAB)
     list(APPEND BLOCKFACTORY_DEPENDENCIES BlockFactorySimulink)
 endif()

--- a/sources/Tools/CMakeLists.txt
+++ b/sources/Tools/CMakeLists.txt
@@ -1,0 +1,29 @@
+# Copyright (C) Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+set(BLOCKFACTORY_EXISTS_SRC
+    src/BlockfactoryExists.cpp)
+
+add_executable(blockfactory-exists ${BLOCKFACTORY_EXISTS_SRC})
+
+target_link_libraries(blockfactory-exists PRIVATE BlockFactory::Core)
+
+target_compile_warnings(blockfactory-exists
+    WARNINGS_AS_ERRORS ${TREAT_WARNINGS_AS_ERRORS}
+    DEPENDS ENABLE_WARNINGS)
+
+install(
+    TARGETS blockfactory-exists
+    EXPORT BlockFactoryToolsExport
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+install_basic_package_files(BlockFactoryTools
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY AnyNewerVersion
+    EXPORT BlockFactoryToolsExport
+    FIRST_TARGET blockfactory-exists
+    NAMESPACE BlockFactory::
+    NO_CHECK_REQUIRED_COMPONENTS_MACRO)

--- a/sources/Tools/src/BlockfactoryExists.cpp
+++ b/sources/Tools/src/BlockfactoryExists.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#include <cstdlib>
+#include <iostream>
+
+#include "BlockFactory/Core/Block.h"
+#include "BlockFactory/Core/FactorySingleton.h"
+
+int main(int argc, char* argv[])
+{
+    std::string commandName = "blockfactory-exists";
+    if (argc != 3)
+    {
+        std::cout << commandName << ": Utility to check for the existence "
+                  << "of a given block inside a given plugin." << std::endl;
+        std::cout << "USAGE : " << commandName << " pluginName blockName" << std::endl;
+        std::cout << "      : Note that the pluginName should be specified without prefix (lib) or suffix (.dll, .so, .dylib)." << std::endl;
+
+        return EXIT_FAILURE;
+    }
+
+    // Get the class name and the library name from the parameter
+    const std::string blockName(argv[2]);
+    const std::string pluginName(argv[1]);
+
+    // Get the block factory
+    auto factory = blockfactory::core::ClassFactorySingleton::getInstance().getClassFactory(
+        {pluginName, blockName});
+
+    if (!factory) {
+        std::cerr << "ERROR: Failed to get factory object (blockName=" << blockName
+                << ",pluginName=" << pluginName << ")";
+        return EXIT_FAILURE;
+    }
+
+    if (!factory->isValid()) {
+        std::cerr << "ERROR: Factory error (" << static_cast<std::uint32_t>(factory->getStatus())
+                << "): " << factory->getError().c_str();
+        return EXIT_FAILURE;
+    }
+
+    std::cout << "SUCCESS: Block \"" << blockName
+              << "\" found and loaded from plugin \"" << pluginName << "\"." << std::endl;
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Add a simple command line tool to check if a given block exists in a given plugin.

Added Tools CMake component to contain command line tools.

For example, if WB-Toolbox is installed correctly and `BLOCKFACTORY_PLUGIN_PATH` is set correctly, this are the output of the command:
~~~
STraversaro@IITICUBLAP102 MINGW64 /c/src/robotology-superbuild/build/src/BlockFactory (master)
$ blockfactory-exists WBToolbox ForwardKinematics
SUCCESS: Block "ForwardKinematics" found and loaded from plugin "WBToolbox".

STraversaro@IITICUBLAP102 MINGW64 /c/src/robotology-superbuild/build/src/BlockFactory (master)
$ echo $?
0

STraversaro@IITICUBLAP102 MINGW64 /c/src/robotology-superbuild/build/src/BlockFactory (master)
$ blockfactory-exists WBToolbox BlockThatDoesNotExists
ERROR: Failed to get factory object (blockName=BlockThatDoesNotExists,pluginName=WBToolbox)
STraversaro@IITICUBLAP102 MINGW64 /c/src/robotology-superbuild/build/src/BlockFactory (master)
$ echo $?
1
~~~