### PR TITLE
Include What You Use: Always include cstdint when necessary

### DIFF
--- a/deps/sharedlibpp/src/shlibpp/SharedLibraryFactory.h
+++ b/deps/sharedlibpp/src/shlibpp/SharedLibraryFactory.h
@@ -10,6 +10,7 @@
 #define SHAREDLIBPP_SHAREDLIBRARYFACTORY_H
 
 #include <shlibpp/api.h>
+#include <cstdint>
 #include <string>
 
 namespace shlibpp {

--- a/sources/Core/src/FactorySingleton.cpp
+++ b/sources/Core/src/FactorySingleton.cpp
@@ -8,6 +8,7 @@
 
 #include "BlockFactory/Core/FactorySingleton.h"
 
+#include <cstdint>
 #include <map>
 #include <string>
 #include <vector>

--- a/sources/Tools/src/BlockfactoryExists.cpp
+++ b/sources/Tools/src/BlockfactoryExists.cpp
@@ -6,6 +6,7 @@
  * GNU Lesser General Public License v2.1 or any later version.
  */
 
+#include <cstdint>
 #include <cstdlib>
 #include <iostream>
 


### PR DESCRIPTION
`uint32_t` was used in a few files without using the appropriate include `cstdint`. Probably in some cases this worked thanks to transitive includes.

Fix https://github.com/robotology/blockfactory/issues/71 .