### PR TITLE
Add workaround to permit to take in input const signal in Simulink autogenerated code

### DIFF
--- a/matlab/BlockFactory.tlc
+++ b/matlab/BlockFactory.tlc
@@ -202,9 +202,10 @@
     %endif
     %%assign width = LibBlockInputSignalWidth(i)
     %assign address = LibBlockInputSignalAddr(i, "", "", 0)
+    // The const_cast is a workaround to solve https://github.com/robotology/blockfactory/issues/81
     blockInfo->setInputPort(
         {%<i>, {%<rows>, %<cols>}, blockfactory::core::Port::DataType::DOUBLE},
-        static_cast<void*>(%<address>));
+        const_cast<void*>(static_cast<const void*>(%<address>)));
     %endforeach
 
     // Outputs


### PR DESCRIPTION
Fix https://github.com/robotology/blockfactory/issues/81
Workaround for https://github.com/robotology/blockfactory/issues/83