### PR TITLE
Switch to use external sharedlibpp instead of internal shlibpp and bump version to 1.0.0

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -58,8 +58,8 @@ Example:
 #define BLOCKFACTORY_CORE_FACTORYSINGLETON_H
 
 #include "BlockFactory/Core/Log.h"
-#include "shlibpp/SharedLibrary.h"
-#include "shlibpp/SharedLibraryClass.h"
+#include "sharedlibpp/SharedLibrary.h"
+#include "sharedlibpp/SharedLibraryClass.h"
 
 #include <memory>
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 # GNU Lesser General Public License v2.1 or any later version.
 
 cmake_minimum_required(VERSION 3.16...3.31)
-project(blockfactory LANGUAGES CXX VERSION 0.8.5)
+project(blockfactory LANGUAGES CXX VERSION 1.0.0)
 
 if(BUILD_DOCS)
     add_subdirectory(doc)
@@ -109,16 +109,16 @@ endif()
 # Handle unit tests support
 option(BUILD_TESTING "Create tests using CMake" OFF)
 
-option(BLOCKFACTORY_USES_SYSTEM_SHLIBPP "If ON, find shlibpp with find_package(shlibpp)" OFF)
-if(BLOCKFACTORY_USES_SYSTEM_SHLIBPP)
-    find_package(shlibpp REQUIRED)
+option(BLOCKFACTORY_USES_SYSTEM_SHAREDLIBPP "If ON, find sharedlibpp with find_package(sharedlibpp)" OFF)
+if(BLOCKFACTORY_USES_SYSTEM_SHAREDLIBPP)
+    find_package(sharedlibpp REQUIRED)
 else()
     include(FetchContent)
     FetchContent_Declare(
-        shlibpp
-        URL https://github.com/ami-iit/shlibpp/archive/refs/tags/v0.0.2.zip
+        sharedlibpp
+        URL https://github.com/ami-iit/sharedlibpp/archive/refs/tags/v0.0.3.zip
     )
-    FetchContent_MakeAvailable(shlibpp)
+    FetchContent_MakeAvailable(sharedlibpp)
 endif()
 
 add_subdirectory(deps)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,7 @@ else()
 endif()
 
 add_subdirectory(deps)
+include(InstallBasicPackageFiles)
 add_subdirectory(sources)
 
 if(USES_MATLAB)

--- a/doc/mkdocs/data/create_new_library.md
+++ b/doc/mkdocs/data/create_new_library.md
@@ -521,7 +521,7 @@ A plugin library usually contains multiple classes used for multiple Blocks. The
 #include "SignalMath.h"
 
 // Class factory API
-#include <shlibpp/SharedLibraryClassApi.h>
+#include <sharedlibpp/SharedLibraryClassApi.h>
 
 // Add the example::SignalMath class to the plugin factory
 SHLIBPP_DEFINE_SHARED_SUBCLASS(SignalMath, example::SignalMath, blockfactory::core::Block);

--- a/example/matlab/AutogenerationExample_grt_rtw/AutogenerationExample.cpp
+++ b/example/matlab/AutogenerationExample_grt_rtw/AutogenerationExample.cpp
@@ -198,7 +198,7 @@ void AutogenerationExampleModelClass::initialize()
         // TODO: find a better way to handle them.
         {
             // Create a new class. This object will be destroyed at the end of the scope.
-            shlibpp::SharedLibraryClass<blockfactory::core::Block> blockPtr(*factory);
+            sharedlibpp::SharedLibraryClass<blockfactory::core::Block> blockPtr(*factory);
             auto tmpCoderBlockInfo = std::unique_ptr<blockfactory::coder::CoderBlockInformation>(
                 new blockfactory::coder::CoderBlockInformation);
             tmpCoderBlockInfo->storeRTWParameters(params);

--- a/example/src/Factory.cpp
+++ b/example/src/Factory.cpp
@@ -1,7 +1,7 @@
 #include "SignalMath.h"
 
 // Class factory API
-#include <shlibpp/SharedLibraryClassApi.h>
+#include <sharedlibpp/SharedLibraryClassApi.h>
 
 // Add the example::SignalMath class to the plugin factory
 SHLIBPP_DEFINE_SHARED_SUBCLASS(SignalMath, example::SignalMath, blockfactory::core::Block);

--- a/matlab/BlockFactory.tlc
+++ b/matlab/BlockFactory.tlc
@@ -237,7 +237,7 @@
     // TODO: find a better way to handle them.
     {
         // Create a new class. This object will be destroyed at the end of the scope.
-        shlibpp::SharedLibraryClass<blockfactory::core::Block> blockPtr(*factory);
+        sharedlibpp::SharedLibraryClass<blockfactory::core::Block> blockPtr(*factory);
 
         auto tmpCoderBlockInfo = std::unique_ptr<blockfactory::coder::CoderBlockInformation>(
             new blockfactory::coder::CoderBlockInformation);

--- a/sources/Core/CMakeLists.txt
+++ b/sources/Core/CMakeLists.txt
@@ -27,7 +27,7 @@ set(CORE_PRIVATE_HDR
 add_library(Core ${CORE_SRC} ${CORE_PUBLIC_HDR} ${CORE_PRIVATE_HDR})
 add_library(BlockFactory::Core ALIAS Core)
 
-target_link_libraries(Core PUBLIC shlibpp::shlibpp)
+target_link_libraries(Core PUBLIC sharedlibpp::sharedlibpp)
 
 target_include_directories(Core PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -55,6 +55,6 @@ install_basic_package_files(BlockFactoryCore
     COMPATIBILITY AnyNewerVersion
     EXPORT BlockFactoryCoreExport
     FIRST_TARGET Core
-    DEPENDENCIES shlibpp
+    DEPENDENCIES sharedlibpp
     NAMESPACE BlockFactory::
     NO_CHECK_REQUIRED_COMPONENTS_MACRO)

--- a/sources/Core/include/BlockFactory/Core/FactorySingleton.h
+++ b/sources/Core/include/BlockFactory/Core/FactorySingleton.h
@@ -10,8 +10,8 @@
 #define BLOCKFACTORY_CORE_FACTORYSINGLETON_H
 
 #include "BlockFactory/Core/Log.h"
-#include "shlibpp/SharedLibrary.h"
-#include "shlibpp/SharedLibraryClass.h"
+#include "sharedlibpp/SharedLibrary.h"
+#include "sharedlibpp/SharedLibraryClass.h"
 
 #include <memory>
 
@@ -23,9 +23,9 @@ namespace blockfactory {
 } // namespace blockfactory
 
 /**
- * @brief Class for interfacing with shlibpp plugin library
+ * @brief Class for interfacing with sharedlibpp plugin library
  *
- * This helper class ease the integration of shlibpp within the BlockFactory framework. It is
+ * This helper class ease the integration of sharedlibpp within the BlockFactory framework. It is
  * implemented with a singleton pattern.
  *
  * It can handle multiple plugin libraries together and provides support of destructing the related
@@ -41,7 +41,7 @@ private:
 #endif
 
 public:
-    using ClassFactory = shlibpp::SharedLibraryClassFactory<blockfactory::core::Block>;
+    using ClassFactory = sharedlibpp::SharedLibraryClassFactory<blockfactory::core::Block>;
     using ClassFactoryPtr = std::shared_ptr<ClassFactory>;
 
     /// @brief Name of the factory associated to the class specified during its registration

--- a/sources/Simulink/CMakeLists.txt
+++ b/sources/Simulink/CMakeLists.txt
@@ -13,7 +13,7 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.24")
         include/BlockFactory/Simulink/Private/SimulinkBlockInformationImpl.h
         src/BlockFactory.cpp
     NO_IMPLICIT_LINK_TO_MATLAB_LIBRARIES
-    LINK_TO ${Matlab_MEX_LIBRARY} ${Matlab_MX_LIBRARY} BlockFactory::Core shlibpp::shlibpp mxpp)
+    LINK_TO ${Matlab_MEX_LIBRARY} ${Matlab_MX_LIBRARY} BlockFactory::Core sharedlibpp::sharedlibpp mxpp)
 else()
    matlab_add_mex(
     NAME Simulink
@@ -23,7 +23,7 @@ else()
         src/SimulinkBlockInformationImpl.cpp
         include/BlockFactory/Simulink/Private/SimulinkBlockInformationImpl.h
         src/BlockFactory.cpp
-    LINK_TO ${Matlab_MEX_LIBRARY} ${Matlab_MX_LIBRARY} BlockFactory::Core shlibpp::shlibpp mxpp)
+    LINK_TO ${Matlab_MEX_LIBRARY} ${Matlab_MX_LIBRARY} BlockFactory::Core sharedlibpp::sharedlibpp mxpp)
 endif()
 add_library(BlockFactory::Simulink ALIAS Simulink)
 
@@ -50,6 +50,6 @@ install_basic_package_files(BlockFactorySimulink
     COMPATIBILITY AnyNewerVersion
     EXPORT BlockFactorySimulinkExport
     FIRST_TARGET Simulink
-    DEPENDENCIES BlockFactoryCore mxpp shlibpp
+    DEPENDENCIES BlockFactoryCore mxpp sharedlibpp
     NAMESPACE BlockFactory::
     NO_CHECK_REQUIRED_COMPONENTS_MACRO)

--- a/tests/Factory/MockPlugin.cpp
+++ b/tests/Factory/MockPlugin.cpp
@@ -9,7 +9,7 @@
 #include "MockPlugin.h"
 #include <BlockFactory/Core/Parameter.h>
 
-#include <shlibpp/SharedLibraryClassApi.h>
+#include <sharedlibpp/SharedLibraryClassApi.h>
 
 mock::MockBlock::MockBlock()
 {


### PR DESCRIPTION
With this change, it is now possible to choose if using the internal `sharedlibpp` dependency, or use an external one, based on the `BLOCKFACTORY_USES_SYSTEM_SHAREDLIBPP` CMake variable.

As the external `sharedlibpp` changed its cmake package name, header directory and C++ namespace from `shlibpp` to `sharedlibpp`, this is effectively a breaking change as changes are required in downstream projects, and hence the version of blockfactory is bumped to 1.0.0 .

For an example of changes that are necessary in a project that depends on `BlockFactory`, check https://github.com/robotology/wb-toolbox/pull/247 .