### PR TITLE
CI: Replace deprecated macos-12 images with macos-13

### DIFF
--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         build_type: [Release]
-        os: [ubuntu-latest, windows-2019, macos-12]
+        os: [ubuntu-latest, windows-2019, macos-13]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
The `macos-12` is now deprecated and will be removed soon, see https://github.com/actions/runner-images/issues/10721 . To continue testing macOS with Intel processor, we can switch to use `macos-13`.